### PR TITLE
Add .torrent file upload and addressed several requests in issues

### DIFF
--- a/components/AddTorrentButton.tsx
+++ b/components/AddTorrentButton.tsx
@@ -23,6 +23,7 @@ import AddTorrentModal from "./AddTorrentModal";
 const AddTorrentButton = () => {
   const [openedMagnet, setOpenedMagnet] = useState(false);
   const [openedURL, setOpenedURL] = useState(false);
+  const [openedFile, setOpenedFile] = useState(false);
   const v2 = useTorrentStore((s) => s.isv2);
 
   const form = useForm<ConfigValues>({
@@ -44,8 +45,11 @@ const AddTorrentButton = () => {
   });
   const [magnet, setMagnet] = useState("");
   const [url, setUrl] = useState("");
+  const [file, setFile] = useState("");
+  const [fileName, setFileName] = useState("");
   const [magnetError, setMagnetError] = useState("");
   const [urlError, setURLError] = useState("");
+  const [fileError, setFileError] = useState("");
   const [debouncedURL] = useDebouncedValue(url, 200);
 
   const addMagnet = trpc.deluge.addMagnet.useMutation();
@@ -84,8 +88,10 @@ const AddTorrentButton = () => {
     }
   );
 
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
   useEffect(() => {
-    if (openedMagnet || openedURL) {
+    if (openedMagnet || openedURL || openedFile) {
       config.refetch();
     }
     if (!openedMagnet) {
@@ -96,7 +102,12 @@ const AddTorrentButton = () => {
       setURLError("");
       setUrl("");
     }
-  }, [openedMagnet, openedURL]);
+    if (!openedFile) {
+      setFile("");
+      setFileName("");
+      setFileError("");
+    }
+  }, [openedMagnet, openedURL, openedFile]);
 
   useEffect(() => {
     if (config.data) {
@@ -112,8 +123,66 @@ const AddTorrentButton = () => {
 
   const context = trpc.useContext();
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setFileName(file.name);
+      const reader = new FileReader();
+      reader.onload = (readerEvent) => {
+        const content = readerEvent.target?.result;
+        if (typeof content === "string") {
+          const base64Content = content.split(",")[1];
+          setFile(base64Content);
+          setOpenedFile(true);
+        }
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   return (
     <>
+      <input
+        type="file"
+        ref={fileInputRef}
+        style={{ display: "none" }}
+        accept=".torrent"
+        onChange={handleFileChange}
+      />
+      <Modal
+        opened={openedFile}
+        onClose={() => setOpenedFile(false)}
+        title="Add Torrent from File"
+      >
+        <Box mx={"auto"}>
+          <Text weight="bold" size="sm" mb="xs">
+            File: {fileName}
+          </Text>
+          <AddTorrentModal form={form} />
+          <Space h={"md"} />
+          <Group position="right">
+            <Button
+              type="submit"
+              onClick={() => {
+                addTorrent.mutate({
+                  path: file,
+                  config: form.values,
+                });
+                setOpenedFile(false);
+              }}
+              disabled={!file}
+              variant="light"
+              color={"blue"}
+              sx={(theme) => ({
+                borderWidth: 1,
+                borderColor: theme.colors.blue,
+              })}
+            >
+              Add
+            </Button>
+          </Group>
+        </Box>
+      </Modal>
       <Modal
         opened={openedMagnet}
         onClose={() => setOpenedMagnet(false)}
@@ -254,6 +323,12 @@ const AddTorrentButton = () => {
         </Menu.Target>
         <Menu.Dropdown>
           <Menu.Label>Add Torrent</Menu.Label>
+          <Menu.Item
+            onClick={() => fileInputRef.current?.click()}
+            icon={<IconFile size={14} />}
+          >
+            File
+          </Menu.Item>
           <Menu.Item
             onClick={() => setOpenedMagnet(true)}
             icon={<IconMagnet size={14} />}

--- a/components/AddTorrentModal.tsx
+++ b/components/AddTorrentModal.tsx
@@ -26,9 +26,9 @@ const AddTorrentModal = ({
 }) => {
   return (
     <Accordion variant="separated">
-      <Accordion.Item value="Advance options">
+      <Accordion.Item value="Advanced options">
         <Accordion.Control icon={<IconSettings size={20} color="teal" />}>
-          Advance options
+          Advanced options
         </Accordion.Control>
         <Accordion.Panel>
           <form>

--- a/components/GoToDeluge.tsx
+++ b/components/GoToDeluge.tsx
@@ -1,0 +1,42 @@
+import { Tooltip, ActionIcon, Menu, Box } from "@mantine/core";
+import { IconDroplet } from "@tabler/icons";
+import React from "react";
+import { trpc } from "../utils/trpc";
+
+const GoToDeluge = () => {
+
+const delugeURL = trpc.deluge.getDelugeURL.useQuery(undefined, {
+  staleTime: Infinity,
+}); 
+
+const goToDeluge = () => {
+  window.open(delugeURL.data?.toString(), '_blank')
+}
+
+  return (
+
+        <Tooltip
+          withinPortal
+          label="Go To Deluge"
+          position="bottom"
+          withArrow
+          color={"blue"}
+        >
+          <ActionIcon
+            radius={"sm"}
+            ml={"md"}
+            sx={(theme) => ({
+              borderWidth: 1,
+              borderColor: theme.colors.blue,
+            })}
+            variant="light"
+            color={"blue"}
+            size={"xl"}
+            onClick={goToDeluge}
+          >
+            <IconDroplet />
+          </ActionIcon>
+        </Tooltip>
+  );
+};
+export default GoToDeluge;

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -43,7 +43,7 @@ const NavBar = () => {
     (filter.find((s) => s.id === "name")?.value as string) || ""
   );
   const [debounced] = useDebouncedValue(value, 200);
-
+  const [isMagnetMode, setIsMagnetMode] = useState<boolean>(false);
   const info = trpc.deluge.getHostInfo.useMutation();
   const setIsv2 = useTorrentStore((s) => s.setIsv2);
   const v2 = useTorrentStore((s) => s.isv2);
@@ -86,8 +86,7 @@ const NavBar = () => {
   }
 
   const handleKeyPress = (event: { key: string; }) =>{
-    console.log(value)
-    if(event.key === "Enter" && value.toLowerCase().startsWith("magnet:")){
+    if(event.key === "Enter" && isMagnetMode){
       startMagnetDownload();
     } 
   }
@@ -117,11 +116,24 @@ const NavBar = () => {
   }, [debounced]);
 
   useEffect(() => {
+      config.refetch();
+  }, [isMagnetMode]);
+
+  useEffect(() => {
       if (config.data) {
         form.setValues(config.data);
       }
     }, [config.data]);
-
+  
+  useEffect(() => {
+      if (value.toLowerCase().startsWith("magnet:")) {
+        setIsMagnetMode(true);
+      }else{
+        setIsMagnetMode(false);
+      }
+      console.log(isMagnetMode);
+    }, [value]);
+    
 
   return (
     <Card
@@ -155,7 +167,7 @@ const NavBar = () => {
           onChange={(event) => setValue(event.currentTarget.value)}
           styles={{ input: { background: theme.colors.dark[8] } }}
           placeholder="Search Torrents or Paste Magnet URL"
-          icon={value.toLowerCase().startsWith("magnet:") ? <IconMagnet /> : <IconSearch />}
+          icon={isMagnetMode ? <IconMagnet /> : <IconSearch />}
           onKeyDown={handleKeyPress}
         />
     <Sort />
@@ -163,7 +175,7 @@ const NavBar = () => {
     <GoToDeluge />
   </Box>
 
-  {value.toLowerCase().startsWith("magnet:") && (
+  {isMagnetMode && (
     <Box pt="md">
           <Space h={"xs"} />
           {magnetinfo.data && (

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,17 +1,23 @@
 import {
+  Accordion,
   ActionIcon,
+  Box,
+  Button,
   Card,
+  Group,
+  Space,
+  Text,
   TextInput,
   Tooltip,
   useMantineTheme,
 } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
-import { IconFilter, IconSearch, IconSortDescending } from "@tabler/icons";
+import { IconFilter, IconSearch, IconMagnet, IconSortDescending, IconSettings } from "@tabler/icons";
 import { Column, Table } from "@tanstack/react-table";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { useMemo } from "react";
-import { NormalizedTorrent } from "../deluge";
+import { ConfigValues, NormalizedTorrent } from "../deluge";
 import { router } from "../server/trpc";
 import useTableStore from "../stores/useTableStore";
 import useTorrentStore from "../stores/useTorrentStore";
@@ -21,6 +27,12 @@ import Filter from "./Filter";
 import MemoizedSort from "./Sort";
 import Sort from "./Sort";
 import Statusbar from "./Statusbar";
+import TorrentOptionForm from "./TorrentOptionForm";
+import GoToDeluge from "./GoToDeluge";
+import { useForm } from "@mantine/form";
+import AddTorrentModal from "./AddTorrentModal";
+
+
 
 const NavBar = () => {
   const router = useRouter();
@@ -34,6 +46,54 @@ const NavBar = () => {
 
   const info = trpc.deluge.getHostInfo.useMutation();
   const setIsv2 = useTorrentStore((s) => s.setIsv2);
+  const v2 = useTorrentStore((s) => s.isv2);
+  const addMagnet = trpc.deluge.addMagnet.useMutation();
+    const magnetinfo = trpc.deluge.magnetInfo.useQuery(
+      { magnet: value },
+      {
+        enabled: !!value,
+      }
+    );
+
+  const form = useForm<ConfigValues>({
+    initialValues: {
+      add_paused: false,
+      compact_allocation: undefined,
+      download_location: "",
+      max_connections_per_torrent: -1,
+      max_download_speed_per_torrent: -1,
+      move_completed: false,
+      move_completed_path: "",
+      max_upload_slots_per_torrent: -1,
+      max_upload_speed_per_torrent: -1,
+      prioritize_first_last_pieces: false,
+      pre_allocate_storage: undefined,
+      sequential_download: undefined,
+      super_seeding: undefined,
+    },
+  });
+
+  const config = trpc.deluge.configValue.useQuery(
+    { v2: v2 },
+    {
+      enabled: false,
+    }
+  );  
+
+  const startMagnetDownload = ()=> {
+    addMagnet.mutate({ magnet: value, config: form.values });
+    setValue("");
+  }
+
+  const handleKeyPress = (event: { key: string; }) =>{
+    console.log(value)
+    if(event.key === "Enter" && value.toLowerCase().startsWith("magnet:")){
+      startMagnetDownload();
+    } 
+  }
+  
+
+
   useEffect(() => {
     info.mutate();
   }, []);
@@ -56,6 +116,13 @@ const NavBar = () => {
     ]);
   }, [debounced]);
 
+  useEffect(() => {
+      if (config.data) {
+        form.setValues(config.data);
+      }
+    }, [config.data]);
+
+
   return (
     <Card
       sx={{
@@ -70,14 +137,15 @@ const NavBar = () => {
       </Card.Section>
 
       <Card.Section
-        p={"md"}
-        sx={{
-          display: "flex",
-        }}
-      >
-        <AddTorrentButton />
-
-        <TextInput
+  p="md"
+  sx={{
+    display: "flex",
+    flexDirection: "column",
+  }}
+>
+  <Box sx={{ display: "flex" }}>
+    <AddTorrentButton />
+    <TextInput
           size="md"
           value={value}
           sx={{
@@ -86,13 +154,44 @@ const NavBar = () => {
           }}
           onChange={(event) => setValue(event.currentTarget.value)}
           styles={{ input: { background: theme.colors.dark[8] } }}
-          placeholder="Search Torrents"
-          icon={<IconSearch />}
+          placeholder="Search Torrents or Paste Magnet URL"
+          icon={value.toLowerCase().startsWith("magnet:") ? <IconMagnet /> : <IconSearch />}
+          onKeyDown={handleKeyPress}
         />
+    <Sort />
+    <Filter />
+    <GoToDeluge />
+  </Box>
 
-        <Sort />
-        <Filter />
-      </Card.Section>
+  {value.toLowerCase().startsWith("magnet:") && (
+    <Box pt="md">
+          <Space h={"xs"} />
+          {magnetinfo.data && (
+            <Text color={"dimmed"} weight="bold" size="xs">
+              {magnetinfo.data?.name}
+            </Text>
+          )}
+          <Space h={"md"} />
+          <AddTorrentModal form={form} />
+          <Space h={"md"} />
+          <Group position="right">
+            <Button
+              type="submit"
+              onClick={startMagnetDownload}
+              disabled={!value}
+              variant="light"
+              color={"blue"}
+              sx={(theme) => ({
+                borderWidth: 1,
+                borderColor: theme.colors.blue,
+              })}
+            >
+              Add
+            </Button>
+          </Group>
+        </Box>
+  )}
+</Card.Section>
     </Card>
   );
 };

--- a/components/Torrent.tsx
+++ b/components/Torrent.tsx
@@ -27,7 +27,7 @@ const getStatusTextColor = (
 ): DefaultMantineColor | "dimmed" => {
   switch (state) {
     case TorrentState.downloading:
-      return "green";
+      return "lightgreen";
     case TorrentState.checking:
       return "blue";
     case TorrentState.paused:
@@ -79,12 +79,15 @@ const Torrent = ({
         >
           <Flex align={"center"} justify={"space-between"} gap={"xs"}>
             <div>
+              
               <Center>
-                <Title
-                  color={"dimmed"}
-                  weight={800}
-                  order={largeScreen ? 2 : 3}
-                >{`#${torrent.queuePosition}`}</Title>
+                {torrent.state != TorrentState.seeding &&
+                  <Title
+                    color={"dimmed"}
+                    weight={800}
+                    order={largeScreen ? 2 : 3}
+                  >{`#${torrent.queuePosition}`}</Title>
+                }
 
                 <Text
                   component={Link}
@@ -100,6 +103,7 @@ const Torrent = ({
                   sx={{
                     flex: 1,
                     wordBreak: "break-all",
+                    marginLeft: torrent.state == TorrentState.seeding ? '0px !important' : undefined,
                     "&:hover": {
                       cursor: "pointer",
                       textDecoration: "underline  solid ",
@@ -153,6 +157,7 @@ const Torrent = ({
               style={{ flexGrow: 1 }}
               size={10}
               value={torrent.progress * 100}
+              color={torrent.state == TorrentState.seeding ? "teal" : "blue"}
               radius={"lg"}
             />
           </Flex>

--- a/components/TorrentDetail.tsx
+++ b/components/TorrentDetail.tsx
@@ -47,6 +47,10 @@ const TorrentDetail = ({ id }: { id: string }) => {
             value={torrent.data.ratio.toPrecision(3)}
           />
           <DetailGridCol
+            label="Tracker"
+            value={torrent.data.raw["tracker_host"]}
+          />
+          <DetailGridCol
             label="Peers"
             value={`${torrent.data.connectedPeers} (${torrent.data.totalPeers})`}
           />

--- a/server/routers/deluge.ts
+++ b/server/routers/deluge.ts
@@ -266,6 +266,10 @@ export const deluge = router({
     return res.result;
   }),
 
+  getDelugeURL: protectedProcedure.query(() => {
+    return process.env.DELUGE_URL;
+  }),
+
   setTorrentOption: protectedProcedure
     .input(
       z.object({
@@ -366,7 +370,7 @@ export const deluge = router({
       ) as Partial<AddTorrentOptions>;
       console.log(notNullconfig);
 
-      const added = await delugeClient.addTorrentMagnet(
+      const added = await delugeClient.addTorrent(
         input.path,
         notNullconfig
       );

--- a/stores/useTableStore.ts
+++ b/stores/useTableStore.ts
@@ -31,7 +31,7 @@ const useTableStore = create<TableStoreState>((set) => ({
   },
   sorting: [
     {
-      id: "queuePosition",
+      id: "state",
       desc: false,
     },
   ],


### PR DESCRIPTION
Add File Upload Option
	-File upload option added for .torrent support

UI: Seeding and downloading items look far too similar
	-Changed color of status bar for seeding and downloading items and Removed #0s for seeding torrents

Pasting magnet link in search box should offer to add it as torrent to download
         -Updated search box to support magnet links

Default sorting should show downloading torrents first
	-Now sorting by download state ascending by default

Ability to manage trackers
   -Did request 1 in this issue to show the tracker host in Torrent Details. Leaving 2 & 3 for someone else to do

"Go To Deluge" Button
   -Added new Go To Deluge button in top right